### PR TITLE
feat(Dockerfile): switch crackerjack repo

### DIFF
--- a/cpu/Dockerfile
+++ b/cpu/Dockerfile
@@ -5,6 +5,7 @@ FROM ubuntu:jammy
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG HASHCAT_INSTALL_DIR=/tmp/hashcat_install
+ARG CRACKERJACK_REPO=https://github.com/Yimura/crackerjack.git
 
 ENV ADDRESS 0.0.0.0
 ENV PORT 8080
@@ -25,7 +26,7 @@ COPY --from=wordlist-fetcher /opt/rules /opt/rules
 
 WORKDIR /opt/crackerjack
 
-RUN git clone https://github.com/sadreck/crackerjack.git . --depth=1 &&\
+RUN git clone $CRACKERJACK_REPO . --depth=1 &&\
     pip install -r requirements.txt
 
 COPY entrypoint.sh .


### PR DESCRIPTION
This switch of code base is required to seed the database with the default paths of crackerjack, wordlists, rules, ...

Closes #3 